### PR TITLE
Configure public .github repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @zephyr-ai/security

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
-Describe your pull request!
+Changes proposed in this pull request:
 
-More TBD.
+*
+*
+*
+*

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+**[optional] Jira ticket link**:
+
 Changes proposed in this pull request:
 
 *

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,3 @@
+# Zephyr AI
+
+For more information about Zephyr AI, check out our [website](https://www.zephyrai.bio/).


### PR DESCRIPTION
Changes proposed in this pull request:
* adds the security team as CODEOWNER
* adds a basic PR description template
* adds a simple profile README (public display)