### PR TITLE
Refresh the pull request template wording

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Hi there. Thanks for submitting a pull request!
 
-Please include a description of your submitted change in this PR description.
+Please describe your changes in this PR description.
 You can also include a link to an active Jira ticket that provides relevant context if there is one.
 
 https://policies.zephyrai.bio/sdlc.html

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,12 @@
 <!--
-
-  Hi there. Thanks for submitting a pull request!
-
-  Please motivate your submitted change in one of two ways:
-
-    * include a link to an active Jira ticket that provides the relevant context, or
-    * describe the reasoning and strategy of the change inline in this description.
-
-  ---
-
-  Got a Jira ticket? Link it here!
-
-    **Jira ticket**: [TICKET](https://zephyrai.atlassian.net/browse/TICKET)
-
-  ---
-
-  No ticket? No problem! Just motivate your pull request in this description.
-  Try something like this on for size.
-
-    Changes proposed in this pull request:
-
-    *
-    *
-    *
-    *
-
+Hi there. Thanks for submitting a pull request!
+Please describe the reasoning and strategoy of your submitted change in this PR description.
+You can also include a link to an active Jira ticket that provides relevant context if there is one.
 -->
+# Proposed Changes
+
+<!--
+**Jira ticket**: https://zephyrai.atlassian.net/browse/TICKET
+-->
+
+<!-- Don't forget to motivate your pull request! -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,28 @@
-**[optional] Jira ticket link**:
+<!--
 
-Changes proposed in this pull request:
+  Hi there. Thanks for submitting a pull request!
 
-*
-*
-*
-*
+  Please motivate your submitted change in one of two ways:
+
+    * include a link to an active Jira ticket that provides the relevant context, or
+    * describe the reasoning and strategy of the change inline in this description.
+
+  ---
+
+  Got a Jira ticket? Link it here!
+
+    **Jira ticket**: [TICKET](https://zephyrai.atlassian.net/browse/TICKET)
+
+  ---
+
+  No ticket? No problem! Just motivate your pull request in this description.
+  Try something like this on for size.
+
+    Changes proposed in this pull request:
+
+    *
+    *
+    *
+    *
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Hi there. Thanks for submitting a pull request!
 
-Please describe a description of your submitted change in this PR description.
+Please include a description of your submitted change in this PR description.
 You can also include a link to an active Jira ticket that provides relevant context if there is one.
 
 https://policies.zephyrai.bio/sdlc.html

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,10 @@
 <!--
 Hi there. Thanks for submitting a pull request!
-Please describe the reasoning and strategoy of your submitted change in this PR description.
+
+Please describe a description of your submitted change in this PR description.
 You can also include a link to an active Jira ticket that provides relevant context if there is one.
+
+https://policies.zephyrai.bio/sdlc.html
 -->
 # Proposed Changes
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace


### PR DESCRIPTION
I'm already kind of tired of seeing:

> **[optional] Jira ticket link**:

floating around in pull requests without a ticket associated with it.

I'm also kind of tired of having to delete text just to push up a quick pull request without a Jira ticket. I figure leaving text for humans in markdown, but commented out so it doesn't _always_ end up in the PR unless you delete it, might be the way to go.

Open to thoughts and suggestions!

@zephyr-ai/fullstack 