### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,10 @@
-<!--
 Hi there. Thanks for submitting a pull request!
 
 Please describe your changes in this PR description.
 You can also include a link to an active Jira ticket that provides relevant context if there is one.
 
 https://policies.zephyrai.bio/sdlc.html
--->
+
 # Proposed Changes
 
-<!--
 **Jira ticket**: https://zephyrai.atlassian.net/browse/TICKET
--->
-
-<!-- Don't forget to motivate your pull request! -->


### PR DESCRIPTION
# Proposed Changes

In [our most recent reto](https://zephyrai.atlassian.net/wiki/spaces/ENG/pages/291766273/Retrospective+2023-10-11) we discussed making the PR template required, instead of commented out by default.

This will make it more obvious when developers are not either providing a JIRA link or appropriately describing their pull request.