### PR TITLE
Reduce required boilerplate deletion in PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Hi there. Thanks for submitting a pull request!
 Please describe your changes in this PR description.
 You can also include a link to an active Jira ticket that provides relevant context if there is one.
 
-https://policies.zephyrai.bio/sdlc.html
+https://zephyrai.atlassian.net/wiki/spaces/HELIX/pages/37650458/Secure+Software+Development+and+Product+Security
 -->
 
 **Jira ticket (optional)**: https://zephyrai.atlassian.net/browse/TICKET

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,14 @@
+# Proposed Changes
+
+<!--
 Hi there. Thanks for submitting a pull request!
 
 Please describe your changes in this PR description.
 You can also include a link to an active Jira ticket that provides relevant context if there is one.
 
 https://policies.zephyrai.bio/sdlc.html
+-->
 
-# Proposed Changes
+**Jira ticket (optional)**: https://zephyrai.atlassian.net/browse/TICKET
 
-**Jira ticket**: https://zephyrai.atlassian.net/browse/TICKET
+Describe your changes.


### PR DESCRIPTION
Forcing people to delete more text in every PR is toil / paperwork and I already feel bad for introducing it.

I'm going to leave the bulk of this description commented out, including the policy link, and only uncomment the jira link.

This way if it gets deleted, @ripplekhera will know you intentionally did not want to associate a ticket.

This is what you will see in the PR description box:

```
# Proposed Changes

<!--
Hi there. Thanks for submitting a pull request!

Please describe your changes in this PR description.
You can also include a link to an active Jira ticket that provides relevant context if there is one.

https://zephyrai.atlassian.net/wiki/spaces/HELIX/pages/37650458/Secure+Software+Development+and+Product+Security
-->

**Jira ticket (optional)**: https://zephyrai.atlassian.net/browse/TICKET

Describe your changes.
```

And this is what it will look like.

# Proposed Changes

<!--
Hi there. Thanks for submitting a pull request!

Please describe your changes in this PR description.
You can also include a link to an active Jira ticket that provides relevant context if there is one.

https://zephyrai.atlassian.net/wiki/spaces/HELIX/pages/37650458/Secure+Software+Development+and+Product+Security
-->

**Jira ticket (optional)**: https://zephyrai.atlassian.net/browse/TICKET

Describe your changes.

